### PR TITLE
Replace file extension setting with a complete list of supported file types

### DIFF
--- a/resources/language/english/strings.xml
+++ b/resources/language/english/strings.xml
@@ -41,6 +41,6 @@
     <string id="30126">Missing Scan Results</string>
     <string id="30127">Missing : {0}</string>
     <string id="30128">Log : {0}</string>
-    
+    <string id="30129">Ignored file types</string>
 </strings>
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <setting type="lsep" label="30010" />
-    <setting id="custom_file_extensions" type="text" label="30011" default="mpg, mpeg, avi, flv, wmv, mkv, 264, 3g2, 3gp, ifo, mp4, mov, iso, ogm" />
     <setting id="custom_log_enabled" type="bool" label="30012" default="false" />
 	<setting id="log_file_name" type="folder" label="30013" default="" />
 	<setting id="blacklist" type="text" label="30014" default="sample.,-trailer." />
     <setting id="debug_log_enabled" type="bool" label="30015" default="false" />
+    <setting id="blacklisted_file_extensions" type="text" label="30129" default=".bin|.dat" />
 </settings>
 


### PR DESCRIPTION
Xbmc supports over 70 different extensions, which you can get with the `xbmc.getSupportedMedia`.

Also adds a new setting for blacklisting extensions so people can hide certain file types if they want (there are some odd ones in there).
