### PR TITLE
Unicode fixes

### DIFF
--- a/default.py
+++ b/default.py
@@ -14,7 +14,6 @@ __settings__ = xbmcaddon.Addon(id='plugin.video.mms')
 language = __settings__.getLocalizedString
 
 LOG_ENABLED = False
-DEBUG_LOGGING = False
 handle = int(sys.argv[1])
 
 # plugin modes
@@ -37,13 +36,8 @@ filesFound = 0
 #############################################################################################
 
 def log(line):
-    if DEBUG_LOGGING:
-        print "MMS : " + line#repr(line)
-        
-    #xbmc.log(line, 2)
-    #xbmc.log("Test", 0) #Debug
-    #xbmc.log("text", 1) #Info
-    #xbmc.log("Test", 2) #Notive
+    xbmc.log('[plugin.video.mms] ' + line, level=xbmc.LOGDEBUG)
+
 
 def clean_name(text):
     text = text.replace('%21', '!')
@@ -160,9 +154,7 @@ def walk_Path(path, walked_files, progress):
     # double slash the \ in the path
     path = path.replace("\\", "\\\\")
     rpcCall = "{\"jsonrpc\": \"2.0\", \"method\": \"Files.GetDirectory\", \"params\": {\"directory\": \"" + path + "\"}, \"id\": 1}"
-    #log("rpcCall: " + rpcCall)
     jsonResult = xbmc.executeJSONRPC(rpcCall)
-    #log("Files.GetDirectory results: " + jsonResult)
     
     # json.loads expects utf-8 but the conversion using unicode breaks stuff
     #jsonResult = unicode(jsonResult, 'utf-8', errors='ignore')
@@ -522,9 +514,7 @@ params = parameters_string_to_dict(sys.argv[2])
 mode = int(urllib.unquote_plus(params.get(PARAMETER_KEY_MODE, "0")))
 source = urllib.unquote_plus(params.get(PARAMETER_KEY_SOURCE, ""))
 LOG_ENABLED = xbmcplugin.getSetting(handle, "custom_log_enabled") == "true"
-DEBUG_LOGGING = xbmcplugin.getSetting(handle, "debug_log_enabled") == "true"
 log("Missing Logging : " + str(LOG_ENABLED))
-log("Debug Logging : " + str(DEBUG_LOGGING))
 FILE_EXTENSIONS = xbmc.getSupportedMedia('video').decode('utf-8').split('|')
 BLACKLISTED_EXTENSIONS = xbmcplugin.getSetting(handle, "blacklisted_file_extensions").decode('utf-8').split('|')
 BLACKLIST_STRINGS = get_blacklist(xbmcplugin.getSetting(handle, "blacklist"))

--- a/default.py
+++ b/default.py
@@ -49,9 +49,7 @@ def clean_name(text):
 
     return text
     
-def get_movie_sources():    
-    log("get_movie_sources() called")
-    
+def get_movie_sources():
     jsonResult = xbmc.executeJSONRPC('{"jsonrpc": "2.0", "method": "Files.GetSources", "params": {"media": "video"}, "id": 1}')
     log("VideoLibrary.GetSources results:\n" + jsonResult)
     shares = eval(jsonResult)#json.loads(jsonResult)
@@ -66,9 +64,7 @@ def get_movie_sources():
     for s in shares:
         share_label = s['label']
         share_path = s['file']
-        
-        log("FOUND SOURCE: " + share_label + " - " + share_path)
-        
+
         if share_path.startswith('addons://'):
             log("DROPPING SOURCE: " + share_label + " - " + share_path)
         elif share_path.startswith('multipath://'):
@@ -78,14 +74,12 @@ def get_movie_sources():
 
             for b in parts:
                 if b:
-                    log("ADDING SOURCE: " + share_label + " - " + b)
                     share = {}
                     share['path'] = b
                     share['name'] = share_label
                     results.append(share)                
 
         else:
-            log("ADDING SOURCE: " + share_label + " - " + share_path)
             share = {}
             share['path'] = share_path
             share['name'] = share_label
@@ -101,8 +95,6 @@ def get_blacklist(blacklist_string):
         blackword = bit.strip().lower()
         if len(blackword) > 0:
             blacklist.append(blackword)
-            log("Adding Blacklist String : " + blackword)
-    
     return blacklist
 
 def get_extensions(ext_string):
@@ -112,8 +104,6 @@ def get_extensions(ext_string):
     for bit in bits:
         ext = bit.strip().lower()
         extensions.append(ext)
-        log("Adding Extension : " + ext)
-    
     return extensions
 
 
@@ -205,8 +195,6 @@ def walk_Path(path, walked_files, progress):
                 walked_files.append(file_name)
 
 def get_files(paths, progress):
-    log("get_files(path) called")
-    
     walked_files = []
     
     for path in paths:
@@ -367,14 +355,11 @@ def auto_detect_sources(library_files):
     
     for source in sources:
         source_paths_pre_select.append(source['path'])
-        log("Auto Select Source Path1 : " + source['path'])
-    
+
     # sort the source paths from longest to shortest
     # this is so we hit our nested paths first
     source_paths_pre_select = sorted(source_paths_pre_select, cmp=path_len_compare)
-    for source in source_paths_pre_select:
-        log("Auto Select Source Path2 : " + source)
-        
+
     # now iterate the library to count our source path uses
     source_paths_count = {}
     

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,7 +4,6 @@
     <setting id="custom_log_enabled" type="bool" label="30012" default="false" />
 	<setting id="log_file_name" type="folder" label="30013" default="" />
 	<setting id="blacklist" type="text" label="30014" default="sample.,-trailer." />
-    <setting id="debug_log_enabled" type="bool" label="30015" default="false" />
     <setting id="blacklisted_file_extensions" type="text" label="30129" default=".bin|.dat" />
 </settings>
 


### PR DESCRIPTION
Fixes several cases of UnicodeDecodeError when using non-ascii characters in the plugin, and replaces `eval` with json.loads.

json.loads doesn't breaks stuff when using unicode everywhere and it is encoded/decoded properly. See http://wiki.xbmc.org/index.php?title=Add-on_unicode_paths for info on how unicode should be handled in xbmc addons.

This is based off #4
